### PR TITLE
Updates the list of packages to install

### DIFF
--- a/config.sh
+++ b/config.sh
@@ -24,9 +24,9 @@ packages_base=( base base-devel syslinux )
 
 packages_intermediate=( boost ed firefox firefox-i18n-fr fpc \
 	 gambit-c gcc-ada gdb git grml-zsh-config htop jdk7-openjdk \
-	 lxqt-common lxqt-config lxqt-panel lxqt-policykit lxqt-qtplugin \
+	 lxqt-themes lxqt-config lxqt-panel lxqt-policykit lxqt-qtplugin \
 	 lxqt-runner lxqt-session openbox oxygen-icons pcmanfm-qt luajit mono \
-	 mono-basic mono-debugger nodejs ntp ntfs-3g ocaml openssh php python \
+	 nodejs ntp ntfs-3g ocaml openssh php python \
 	 python2 qtcreator rlwrap rxvt-unicode screen sddm tmux ttf-dejavu \
 	 valgrind wget xorg xf86-video-intel xorg-apps zsh vim emacs \
 	 networkmanager network-manager-applet xterm zeal )
@@ -36,4 +36,5 @@ packages_big=( codeblocks eclipse-java eclipse-ecj eric \
 	 monodevelop-debugger-gdb netbeans  openjdk7-doc \
 	 reptyr rsync samba scite )
 
-packages_aur=( esotope-bfc-git notepadqq pycharm-community sublime-text )
+packages_aur=( esotope-bfc-git notepadqq pycharm-community sublime-text \
+	 mono-basic mono-debugger )


### PR DESCRIPTION
- lxqt-common a été remplacé par lxqt-themes
- mono-basic et mono-debugger ne sont plus disponibles que dans l'AUR