### PR TITLE
Add VS Code to the package list

### DIFF
--- a/config.sh
+++ b/config.sh
@@ -32,6 +32,6 @@ packages_intermediate=( boost ed firefox firefox-i18n-fr fpc \
 
 packages_big=( codeblocks eclipse-java eclipse-ecj eric \
 	 eric-i18n-fr geany ghc leafpad netbeans  openjdk7-doc \
-	 reptyr rsync samba pycharm-community-edition )
+	 reptyr rsync samba pycharm-community-edition code )
 
 packages_aur=( esotope-bfc-git sublime-text-dev )


### PR DESCRIPTION
I would like [Visual Studio Code](https://code.visualstudio.com/) to be added to the package list as it is a very popular code editor.

Its open source build, which is the one I want to add to the package list with this pull request, is available in the Community repository of Arch Linux.