### PR TITLE
network/iptable: do not drop packets to localhost

### DIFF
--- a/root_skel/etc/NetworkManager/dispatcher.d/pre-up.d/00_filter.sh
+++ b/root_skel/etc/NetworkManager/dispatcher.d/pre-up.d/00_filter.sh
@@ -7,4 +7,5 @@ subnet="$(ip -o a show dev "$device" scope global | awk '{ print $4 }')"
 iptables -F
 
 iptables -A OUTPUT -d "$subnet" -j ACCEPT
+iptables -A OUTPUT -d 127.0.0.1/32 -j ACCEPT
 iptables -P OUTPUT DROP


### PR DESCRIPTION
Some IDE we use communicate with processes via localhost, but the
"drop" policy on OUTPUT blocks those communications, this commit adds an
ACCEPT rule on outbound packets to localhost.