### PR TITLE
Er2020

### DIFF
--- a/config.sh
+++ b/config.sh
@@ -16,7 +16,7 @@
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-image_size='3824M'
+image_size='7648M'
 part_mode='gpt'
 aur_cache='pkg_root'
 

--- a/config.sh
+++ b/config.sh
@@ -29,10 +29,10 @@ packages_intermediate=( boost ed firefox firefox-i18n-fr fpc \
 	 python2 qtcreator rlwrap rxvt-unicode screen sddm tmux ttf-dejavu \
 	 valgrind wget xorg xf86-video-intel xorg-apps zsh vim emacs \
 	 networkmanager network-manager-applet xterm zeal \
-     jre8-openjdk-headless jdk8-openjdk jre8-openjdk)
+         jre8-openjdk-headless jdk8-openjdk jre8-openjdk rust mono )
 
 packages_big=( codeblocks eclipse-java eclipse-ecj eric \
 	 geany ghc leafpad netbeans  openjdk7-doc \
 	 reptyr rsync samba pycharm-community-edition code atom )
 
-packages_aur=( esotope-bfc-git sublime-text-dev )
+packages_aur=( esotope-bfc-git sublime-text-dev rider )

--- a/filesystems.sh
+++ b/filesystems.sh
@@ -89,7 +89,7 @@ install_dos_efi_bootloader () {
     mount "${dev_boot}" "$1"
     for file in "${1}/EFI/"{systemd/systemd-bootx64.efi,Bootx64.efi}; do
 	mkdir -p -- "$(dirname "${file}")"
-	cp /usr/lib/systemd/efi/systemd-bootx64.efi "${file}"
+	cp /usr/lib/systemd/boot/efi/systemd-bootx64.efi "${file}"
     done
 
     mkdir -p "${1}/loader/entries"

--- a/prololive.dos
+++ b/prololive.dos
@@ -1,7 +1,7 @@
 label: dos
-label-id: 0xe4b9a144
+label-id: 0x549ddabe
 device: prololive.img
 unit: sectors
 
-prololive.img1 : start=        2048, size=     5783552, type=83, bootable
-prololive.img2 : start=     5785600, size=     2043904, type=83
+prololive.img1 : start=        2048, size=     8388608, type=83, bootable
+prololive.img2 : start=     8390656, size=     6291456, type=83

--- a/prololive.gpt
+++ b/prololive.gpt
@@ -1,10 +1,10 @@
 label: gpt
-label-id: 961799D8-D3A0-4A11-9BB1-3DABAC38F587
+label-id: D2965256-77A1-C441-B0C6-B7C6BC3D8724
 device: prololive.img
 unit: sectors
 first-lba: 2048
-last-lba: 7831518
+last-lba: 15663070
 
-prololive.img1 : start=        2048, size=     5218304, type=C12A7328-F81F-11D2-BA4B-00A0C93EC93B, uuid=A93B8742-02C7-44D0-A0E8-48558C506C88, name="EFI Filesystem"
-prololive.img2 : start=     5220352, size=     2097152, type=0FC63DAF-8483-4772-8E79-3D69D8477DE4, uuid=763A2826-6905-42D6-8D61-28445AE69ACE, name="Persistent storage"
-prololive.img3 : start=     7317504, size=        2048, type=21686148-6449-6E6F-744E-656564454649, uuid=EFFCF2DF-E4D3-4286-9AEC-71EB63FE154D, name="BIOS Boot"
+prololive.img1 : start=        2048, size=     8388608, type=C12A7328-F81F-11D2-BA4B-00A0C93EC93B, uuid=091ABE4B-2DB0-854C-A4F6-75FE202A17FD, name="EFI Filesystem"
+prololive.img2 : start=     8390656, size=     6291456, type=0FC63DAF-8483-4772-8E79-3D69D8477DE4, uuid=F5911FD4-CD3B-394B-95FA-6E1A93D0C431, name="Persistent storage"
+prololive.img3 : start=    14682112, size=        2048, type=21686148-6449-6E6F-744E-656564454649, uuid=6E3F5C78-8912-E245-AE34-BA5189D7286B, name="BIOS Boot"


### PR DESCRIPTION
In this PR are a couple of fixes needed for the envlive images:

* added rust language
* added mono and rider (the C# IDE)
* make the image larger to hold rust and rider
* fixed the path to systemd-boot's EFI binary

When enlarging the image, in order to avoid having this problem I made it pretty (absurdly) big.

Since USB drive go from 4GiB to 8GiB generally,  I bumped the size from 3.7GiB to 7.4GiB.

The boot partition (holding the squashfs files) is now 4GiB and the persistent partition 3.4GiB.

As the packages and supported languages grow larger we can shrink the persistent one to enlargent the boot one (the persistent one used to be just a few MiB (about 200).