### PR TITLE
network/iptable: do not drop packets to 127/8

### DIFF
--- a/root_skel/etc/NetworkManager/dispatcher.d/pre-up.d/00_filter.sh
+++ b/root_skel/etc/NetworkManager/dispatcher.d/pre-up.d/00_filter.sh
@@ -7,5 +7,5 @@ subnet="$(ip -o a show dev "$device" scope global | awk '{ print $4 }')"
 iptables -F
 
 iptables -A OUTPUT -d "$subnet" -j ACCEPT
-iptables -A OUTPUT -d 127/8 -j ACCEPT
+iptables -A OUTPUT -d 127.0.0.0/8 -j ACCEPT
 iptables -P OUTPUT DROP

--- a/root_skel/etc/NetworkManager/dispatcher.d/pre-up.d/00_filter.sh
+++ b/root_skel/etc/NetworkManager/dispatcher.d/pre-up.d/00_filter.sh
@@ -7,4 +7,5 @@ subnet="$(ip -o a show dev "$device" scope global | awk '{ print $4 }')"
 iptables -F
 
 iptables -A OUTPUT -d "$subnet" -j ACCEPT
+iptables -A OUTPUT -d 127/8 -j ACCEPT
 iptables -P OUTPUT DROP


### PR DESCRIPTION
See #16 : this PR allows packets to be sent to `127.0.1.1` and more generally `127/8` instead of only `127.0.0.1` as in @Dettorer's original work.